### PR TITLE
トリボナッチ数列を出力

### DIFF
--- a/src/main/scala-2.11/Main.scala
+++ b/src/main/scala-2.11/Main.scala
@@ -1,3 +1,3 @@
 object Main {
-  val tribs: Stream[Int] = ???
+  val tribs: Stream[Int] =  0 #:: 0 #:: 1 #:: tribs.zip(tribs.tail).zip(tribs.tail.tail).map { n => n._1._1 + n._1._2 + n._2 }
 }


### PR DESCRIPTION
バージョン違いでうまく動作しません。
ちょっとややこしかったので後で復讐しようと思います。
マージは不要です。